### PR TITLE
Reporting fixes

### DIFF
--- a/analyze-clusterbuster-report
+++ b/analyze-clusterbuster-report
@@ -34,10 +34,13 @@ parser.add_argument("--kata", action='store_true', help='Compare results for sta
 parser.add_argument("-r", "--report-type", "--report_type", default=None, type=str, metavar='format',
                     choices=analysis_formats, help=f'Analysis format: one of {", ".join(analysis_formats)}')
 parser.add_argument("-w", "--workload", type=str, help='Workloads to process', action='append')
-parser.add_argument("files", metavar='file', type=str, nargs='+', help='Files to process')
+parser.add_argument("files", metavar='file', type=str, nargs='*', help='Files to process')
 args, extras = parser.parse_known_args()
 if args.list_formats:
     print('\n'.join(sorted(analysis_formats)))
+    sys.exit()
+elif not args.files:
+    print("Error: at least one file or directory must be specified");
     sys.exit(1)
 
 

--- a/lib/clusterbuster/reporting/analysis/summary/fio_analysis.py
+++ b/lib/clusterbuster/reporting/analysis/summary/fio_analysis.py
@@ -22,7 +22,7 @@ class fio_analysis(ClusterBusterAnalyzeSummaryGeneric):
     """
 
     def __init__(self, workload: str, data: dict, metadata: dict):
-        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', '-By Fdatasync', '-By Direct', 'By Operation', 'By Blocksize']
+        dimensions = ['By Pod Count', 'By Engine', 'By I/O Depth', 'By Numjobs', '-By Fdatasync', '-By Direct', 'By Operation', 'By Blocksize']
         variables = ['throughput', 'iops', 'latency_avg', 'latency_max']
         filters = {
             'By Direct': self.__filter_direct


### PR DESCRIPTION
- Add numjobs to summary fio analysis
- analyze-clusterbuster-report --list-formats should not error if no files are specified